### PR TITLE
configure stream handler to use stdout

### DIFF
--- a/TwitchChannelPointsMiner/logger.py
+++ b/TwitchChannelPointsMiner/logger.py
@@ -2,6 +2,7 @@ import logging
 import os
 import platform
 import queue
+import sys
 from datetime import datetime
 from logging.handlers import QueueHandler, QueueListener, TimedRotatingFileHandler
 from pathlib import Path
@@ -169,7 +170,7 @@ def configure_loggers(username, settings):
     # Send log messages to another thread through the queue
     root_logger.addHandler(queue_handler)
 
-    console_handler = logging.StreamHandler()
+    console_handler = logging.StreamHandler(sys.stdout)
     console_handler.setLevel(settings.console_level)
     console_handler.setFormatter(
         GlobalFormatter(


### PR DESCRIPTION
# Description

Change log tracking when running with pm2, by changing the logging to stdout instead of stderr. Allows the INFO messages not to display as errors. 

Could at least be a step towards an option in the run.py file to indicate docker/pm2 use for proper log tracking. 

Fixes # (issue)

https://github.com/Unitech/pm2/issues/4817

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality not to work as expected)

# How Has This Been Tested?

I applied the changes and ran with pm2, and the channel point collection logs no longer were represented as errors.

I did not test the docker image.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (README.md)
- [x] My changes generate no new warnings
- [x] Any dependent changes have been updated in requirements.txt
